### PR TITLE
Store GLA state as float32 in metal kernel

### DIFF
--- a/mlx_lm/models/bailing_moe_linear.py
+++ b/mlx_lm/models/bailing_moe_linear.py
@@ -267,34 +267,20 @@ class BailingMoeLinearLinearAttention(nn.Module):
             queries = self.query_layernorm(queries)
             keys = self.key_layernorm(keys)
 
-        if L == 1 and cache is not None and cache.kv is not None:
+        if cache is not None and cache.kv is not None:
             offset = cache.kv.offset
             queries = self.rope(queries, offset=offset)
             keys = self.rope(keys, offset=offset)
             cache.kv.update_and_fetch(keys, values)
-            T_kv = L
         else:
-            if cache is not None and cache.kv is not None:
-                queries = self.rope(queries, offset=cache.kv.offset)
-                keys = self.rope(keys, offset=cache.kv.offset)
-                keys, values = cache.kv.update_and_fetch(keys, values)
-            else:
-                queries = self.rope(queries)
-                keys = self.rope(keys)
+            queries = self.rope(queries)
+            keys = self.rope(keys)
 
-            if self.num_key_value_groups > 1:
-                keys = mx.repeat(keys, self.num_key_value_groups, axis=1)
-                values = mx.repeat(values, self.num_key_value_groups, axis=1)
+        if self.num_key_value_groups > 1:
+            keys = mx.repeat(keys, self.num_key_value_groups, axis=1)
+            values = mx.repeat(values, self.num_key_value_groups, axis=1)
 
-            T_q, T_kv = queries.shape[2], keys.shape[2]
-            if T_q < T_kv:
-                queries = mx.pad(queries, [(0, 0), (0, 0), (T_kv - T_q, 0), (0, 0)])
-            elif T_q > T_kv:
-                queries = queries[:, :, -T_kv:, :]
-
-            if mask is not None and isinstance(mask, mx.array) and cache is not None:
-                mask_array = mask.astype(mx.float32)
-                values = values * mask_array[:, -queries.shape[2] :, None, None]
+        T_kv = L
 
         g = mx.broadcast_to(
             self.slope[None, :, None], (B, self.num_attention_heads, T_kv)

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -564,7 +564,7 @@ class MambaCache(ArraysCache):
         super().__init__(size=2, left_padding=left_padding)
 
 
-class LinearAttentionCache:
+class LinearAttentionCache(_BaseCache):
     def __init__(self):
         self.kv = KVCache()
         self.gla = ArraysCache(1)
@@ -576,7 +576,22 @@ class LinearAttentionCache:
 
     @property
     def state(self):
-        return self.kv.state
+        return [*self.kv.state, self.gla.cache]
+
+    @state.setter
+    def state(self, v):
+        if v and len(v) >= 2:
+            self.kv.state = (v[0], v[1])
+            self.gla.cache = v[2] if len(v) > 2 else None
+        else:
+            self.kv.state = (None, None)
+            self.gla.cache = None
+
+    def is_trimmable(self):
+        return False
+
+    def trim(self, n):
+        return 0
 
 
 class ChunkedKVCache(KVCache):


### PR DESCRIPTION
This seems to fix the repetition issue I described in for Ring-flash-linear-2.0-8bit in [513](https://github.com/ml-explore/mlx-lm/pull/513). The output of the metal kernel and the python fallback were slightly different (sorry for the excessive casting). Again, please test before merging :)

