### PR TITLE
Fix state upcast

### DIFF
--- a/mlx_lm/models/bailing_moe_linear.py
+++ b/mlx_lm/models/bailing_moe_linear.py
@@ -317,10 +317,11 @@ def group_expert_select(
     norm_topk_prob: bool,
     score_function: str,
 ) -> Tuple[mx.array, mx.array]:
+    in_type = gates.dtype
     if score_function == "sigmoid":
-        scores = mx.sigmoid(gates)
+        scores = mx.sigmoid(gates.astype(mx.float32))
     else:
-        scores = mx.softmax(gates, axis=-1, precise=True)
+        scores = mx.softmax(gates.astype(mx.float32), axis=-1)
     orig_scores = scores
     if e_score_correction_bias is not None:
         scores = scores + e_score_correction_bias
@@ -342,7 +343,7 @@ def group_expert_select(
         scores = scores / denominator
     scores = scores * routed_scaling_factor
 
-    return inds, scores
+    return inds, scores.astype(in_type)
 
 
 class BailingMoeLinearGate(nn.Module):

--- a/mlx_lm/models/fused_recurrent_gla.py
+++ b/mlx_lm/models/fused_recurrent_gla.py
@@ -50,11 +50,11 @@ def _make_fused_recurrent_gla_kernel():
                 float q_scaled_bf16 = (float)(InT)q_scaled_f32;
                 acc += q_scaled_bf16 * h_col[d];
             }
-            y[y_off + dv] = acc;
+            y[y_off + dv] = (InT)acc;
         }
 
         for (int d = 0; d < Dk; ++d) {
-            state_out[state_base + d * Dv] = h_col[d];
+            state_out[state_base + d * Dv] = (InT)h_col[d];
         }
     """
     inputs = ["q", "k", "v", "g", "B", "H_in", "T", "scale", "state_in"]
@@ -165,6 +165,6 @@ def fused_recurrent_gla_update(
         grid=(1, Dv, B * H),
         threadgroup=(1, 1, 1),
         output_shapes=[(B, H, T, Dv), (B, H, Dk, Dv)],
-        output_dtypes=[mx.float32, mx.float32],
+        output_dtypes=[input_type, input_type],
     )
     return y, new_state


### PR DESCRIPTION
I realized my adjustment earlier (upcasting state to float32) was hurting performance and likely didn't contribute to fixing the issue from https://github.com/ml-explore/mlx-lm/pull/513#issuecomment-3408991417. 

I retested the flash models (4, 6, and 8 bit) with these changes and performance is up 40-50% without any side effects in the output. Sorry about that!