### PR TITLE
lora: add --epochs training argument (with --iters compatibility)

### DIFF
--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -60,8 +60,12 @@ mlx_lm.lora \
     --model <path_to_model> \
     --train \
     --data <path_to_data> \
-    --iters 600
+    --epochs 3
 ```
+
+You can use either `--epochs` or `--iters` to control training length. They
+are mutually exclusive. If neither is specified, `mlx_lm.lora` defaults to
+`--iters 1000` for backward compatibility.
 
 To fine-tune the full model weights, add the `--fine-tune-type full` flag.
 Currently supported fine-tuning types are `lora` (default), `dora`, and `full`.

--- a/mlx_lm/LORA.md
+++ b/mlx_lm/LORA.md
@@ -63,9 +63,9 @@ mlx_lm.lora \
     --epochs 3
 ```
 
-You can use either `--epochs` or `--iters` to control training length. They
-are mutually exclusive. If neither is specified, `mlx_lm.lora` defaults to
-`--iters 1000` for backward compatibility.
+You can use either `--epochs` or `--iters` to control training length. If
+both specified, `--epochs` overrides `--iters`. If neither is specified,
+`mlx_lm.lora` defaults to `--iters 1000` for backward compatibility.
 
 To fine-tune the full model weights, add the `--fine-tune-type full` flag.
 Currently supported fine-tuning types are `lora` (default), `dora`, and `full`.

--- a/mlx_lm/lora.py
+++ b/mlx_lm/lora.py
@@ -326,11 +326,14 @@ def run(args, training_callback: TrainingCallback = None):
     train_set, valid_set, test_set = load_dataset(args, tokenizer)
 
     if args.epochs is not None:
-        args.iters = calculate_training_steps(
+        args.iters, steps_per_epoch = calculate_training_steps(
             num_samples=len(train_set),
             batch_size=args.batch_size,
             epochs=args.epochs,
-            grad_accum_steps=1,
+        )
+        print(
+            f"Using epochs={args.epochs} with steps_per_epoch={steps_per_epoch}; "
+            f"resolved to iters={args.iters}."
         )
 
     if args.test and not args.train:

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -16,8 +16,8 @@ from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
 
 
 def calculate_training_steps(
-    num_samples: int, batch_size: int, epochs: int, grad_accum_steps: int = 1
-) -> int:
+    num_samples: int, batch_size: int, epochs: int
+) -> tuple[int, int]:
     """
     Calculates the total effective training steps (TERS) from the given epoch.
 
@@ -25,13 +25,22 @@ def calculate_training_steps(
         num_samples (int): The length of the training dataset.
         batch_size (int): The batch size used during training.
         epochs (int): The current epoch number.
-        grad_accum_steps (int): Number of gradient accumulation steps before one optimizer update. Default is 1.
 
     Returns:
         int: The total effective training steps.
+        int: Number of steps per epoch
     """
-    batches_per_epoch = math.ceil(num_samples / batch_size)
-    return (epochs * batches_per_epoch) // grad_accum_steps
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+    if epochs <= 0:
+        raise ValueError("epochs must be greater than 0.")
+    steps_per_epoch = num_samples // batch_size
+    if steps_per_epoch < 1:
+        raise ValueError(
+            f"Dataset must have at least batch_size={batch_size} "
+            f"examples but only has {num_samples}."
+        )
+    return max(1, math.ceil(epochs * steps_per_epoch)), steps_per_epoch
 
 
 def build_schedule(schedule_config: Dict):

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -28,7 +28,7 @@ def calculate_training_steps(
 
     Returns:
         int: The total effective training steps.
-        int: Number of steps per epoch
+        int: Number of steps per epoch.
     """
     if batch_size < 1:
         raise ValueError("batch_size must be at least 1")

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import mlx.nn as nn
 
 from mlx_lm.tuner.lora import LoRALinear
-from mlx_lm.tuner.utils import print_trainable_parameters
+from mlx_lm.tuner.utils import print_trainable_parameters, calculate_training_steps
 
 
 class TestTunerUtils(unittest.TestCase):
@@ -80,6 +80,23 @@ class TestTunerUtils(unittest.TestCase):
         expected_output = "Trainable parameters: 50.000% (3.000M/6.000M)\n"
         print_trainable_parameters(model)
         self.assertEqual(self.capturedOutput.getvalue(), expected_output)
+
+class TestLoraEpochs(unittest.TestCase):
+    def test_resolve_train_iterations_with_epochs(self):
+        iters, steps_per_epoch = calculate_training_steps(num_samples=10, batch_size=4, epochs=2)
+        self.assertEqual(iters, 4)
+        self.assertEqual(steps_per_epoch, 2)
+
+    def test_resolve_train_iterations_rejects_invalid_epochs(self):
+        with self.assertRaisesRegex(ValueError, "epochs must be greater than 0"):
+            calculate_training_steps(num_samples=100, batch_size=4, epochs=0)
+
+    def test_resolve_train_iterations_rejects_too_small_dataset(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Dataset must have at least batch_size=4 examples but only has 3",
+        ):
+            calculate_training_steps(num_samples=3, batch_size=4, epochs=1)
 
 
 if __name__ == "__main__":

--- a/tests/test_tuner_utils.py
+++ b/tests/test_tuner_utils.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import mlx.nn as nn
 
 from mlx_lm.tuner.lora import LoRALinear
-from mlx_lm.tuner.utils import print_trainable_parameters, calculate_training_steps
+from mlx_lm.tuner.utils import calculate_training_steps, print_trainable_parameters
 
 
 class TestTunerUtils(unittest.TestCase):
@@ -81,9 +81,12 @@ class TestTunerUtils(unittest.TestCase):
         print_trainable_parameters(model)
         self.assertEqual(self.capturedOutput.getvalue(), expected_output)
 
+
 class TestLoraEpochs(unittest.TestCase):
     def test_resolve_train_iterations_with_epochs(self):
-        iters, steps_per_epoch = calculate_training_steps(num_samples=10, batch_size=4, epochs=2)
+        iters, steps_per_epoch = calculate_training_steps(
+            num_samples=10, batch_size=4, epochs=2
+        )
         self.assertEqual(iters, 4)
         self.assertEqual(steps_per_epoch, 2)
 


### PR DESCRIPTION
By @angeloskath request closing my PR #937 and integrating the relevant changes here. @Goekdeniz-Guelmez my attempt is a little more involved, so I felt like it was worth keeping some of those extras from my PR which you don't have in your changes (like the tests, for example).

I kept the `--epochs` parameter "semantics" of your PR with the `--epochs` parameter value overriding the `--iters` parameter value. In my PR they were mutually exclusive, but I think your approach is cleaner (and also requires less changes).

I also believe there's a bug in your changes (which is fixed now) - I don't think you have to account for `--grad-accumulation-steps` when inferring the number of iterations from the number of epochs. This flag doesn't mean the training examples actually batched (only gradient descent is "batched" - executed once per the configured number of steps). So changing this parameter shouldn't affect the number of steps/iterations I believe.
 
## Original description (with adjustments):
This PR adds an `--epochs` parameter to `mlx_lm.lora` so users can specify training length in dataset passes, while preserving existing `--iters` behavior.

## Why
`--iters` is sensitive to dataset size and batch size, which makes run configuration less intuitive and easier to misconfigure. `--epochs` provides a more stable and user-friendly way to express training duration.

## What changed
- ~Added `--epochs` to `mlx_lm.lora` CLI.~
- Added validation and resolution logic:
  - ~`--epochs` and `--iters` are mutually exclusive.~
  - `--epochs` is converted to iterations via:
    - `steps_per_epoch = len(train_set) // batch_size`
    - `iters = ceil(epochs * steps_per_epoch)`
  - Clear input validation for invalid values and too-small datasets.
- Kept trainer internals iteration-based for minimal code churn.
- Preserved backward compatibility:
  - If neither option is provided, behavior remains equivalent to prior default (`iters=1000`).
- Updated docs/examples:
  - `mlx_lm/LORA.md`
  - ~`mlx_lm/examples/lora_config.yaml`~
- Added unit tests for new resolution/validation behavior in <del>`tests/test_finetune.py`</del>`tests/test_tuner_utils.py`.

## Notes
- This change does not alter existing batch construction semantics (remainder samples are still dropped by current iterator behavior).

## Validation
- ~`python -m unittest tests/test_finetune.py`~`python -m unittest tests/test_tuner_utils.py` passed.
- `pre-commit run --all-files` passed.